### PR TITLE
Fix incorrect choose flag error

### DIFF
--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -218,7 +218,7 @@ if [ -z "$dmenu" ]; then
   fi
 fi
 
-if [ $choose -eq 0 ] && [ $list -eq 0 ]; then
+if [ -z "$new" ] && [ $choose -eq 0 ] && [ $list -eq 0 ]; then
   # if user chose neither --choose or --list, assume --choose
   choose=1
 fi


### PR DESCRIPTION
When calling `qutebrowser-profile` with the `--new` flag it exits with code 1 and a message that you cannot use --choose with --new. This happens even when the --choose flag is not provides together with --new.

This is how to reproduce:

``` bash
qutebrowser-profile --new test
cannot use --choose with --new
```