### PR TITLE
allow argumentless qutebrowser invocation

### DIFF
--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -232,7 +232,7 @@ elif [ $choose -eq 1 ]; then
 
   dmenuArgs="-p qutebrowser"
 
-  [ $rofi -eq 1 ] && dmenuArgs="$dmenuArgs -mesg $qbArgs"
+  [ $rofi -eq 1 ] && dmenuArgs="$dmenuArgs -mesg ${qbArgs:-}"
 
   [ $onlyExisting -eq 1 ] && dmenuArgs="$dmenuArgs -no-custom"
 


### PR DESCRIPTION
Fixes error: 

``` bash
$qutebrowser-profile --choose
qutebrowser-profile: line 235: qbArgs: unbound variable
```