### PR TITLE
Fix incorrect choose flag error, load variation.

### DIFF
--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -218,7 +218,7 @@ if [ -z "$dmenu" ]; then
   fi
 fi
 
-if [ -z "$new" ] && [ $choose -eq 0 ] && [ $list -eq 0 ]; then
+if [ -z "$new" ] && [ -z "$load" ] && [ $choose -eq 0 ] && [ $list -eq 0 ]; then
   # if user chose neither --choose or --list, assume --choose
   choose=1
 fi


### PR DESCRIPTION
Whatever broke that required PR #2 to fix calls to --new also affected
calls to --load. Here's the behavior before this patch:

Before:

> ./qutebrowser-profile --load "test"
> cannot use --choose with --load

After applying it, a new profile is loaded and launched as expected.
