### PR TITLE
Add support for unique WM_CLASS/app_id, generate .desktop files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # qutebrowser-profile
 
-A simple wrapper script for qutebrowser that allows you to maintain different profiles, each with their own history and session state but sharing the same `config.py`.
+A wrapper script for qutebrowser that allows you to maintain different profiles, each with their own history and session state but sharing the same `config.py`.
 
 ## Why?
 
@@ -21,9 +21,13 @@ To create a new profile, just call the script:
 You'll get a rofi/dmenu prompt asking for a profile name. Type one in and hit enter, and qutebrowser will load your profile.
 
 Note that:
-* qutebrowser's window will have `[my-profile-name]` at the start, so you can easily distinguish different qutebrowsers loaded with different profiles
-* qutebrowser loads configuration from the normal location (and all qutebrowsers share configuration regardless of profile, this includes quickmarks/bookmarks)
-* other data, such as session history, cache, cookies, etc, will be unique to that profile
+
+ * qutebrowser's window will have `[my-profile-name]` at the start, so you can easily distinguish different qutebrowsers loaded with different profiles
+ * qutebrowser loads configuration from the normal location (and all qutebrowsers share configuration regardless of profile, this includes quickmarks/bookmarks)
+ * other data, such as session history, cache, cookies, etc, will be unique to that profile
+ * A new `.desktop` file will be created for each profile, allowing you to launch each one using a GUI launcher. Name will be "Qute [$profile]"
+ * Each profile will be treated as a unique app by the window managers because we set a unique WM\_CLASS for X11 and a unique app\_id for Wayland (requires Qutebrowser > 1.14.1).
+ * The same Qutebrowser icon is used for the new profiles, but you can reference your own by editing `~/.local/share/applications/qutebrowser-$profile.desktop`.
 
 ## Other options
 

--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -218,7 +218,7 @@ if [ -z "$dmenu" ]; then
   fi
 fi
 
-if [ -z "$new" ] && [ $choose -eq 0 ] && [ $list -eq 0 ]; then
+if [ -z "$new" ] && [ -z "$load" ] && [ $choose -eq 0 ] && [ $list -eq 0 ]; then
   # if user chose neither --choose or --list, assume --choose
   choose=1
 fi

--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -94,6 +94,20 @@ runQbWithProfile() {
   runQb ${qbArgs[@]}
 }
 
+# Copy the canonical Qutebrowser .desktop file and customize it.
+createDesktopFile() {
+  profile="$1"
+  desktopFile="$XDG_DATA_HOME/applications/qutebrowser-$profile.desktop"
+  # XXX Check if this file exists and/or support other locations.
+  cp /usr/share/applications/org.qutebrowser.qutebrowser.desktop $desktopFile
+  appId="qutebrowser-$profile"
+  newExec="Exec=qutebrowser-profile "
+  newExec+="--load '$profile' "
+  sed -i "s/Exec=qutebrowser/$newExec/g;
+          s/Name=qutebrowser/Name=Qute [$profile]/;
+          s/StartupWMClass=qutebrowser/StartupWMClass=$appId/" $desktopFile
+}
+
 # usage: runQb <args>
 runQb() {
   # https://github.com/ayekat/dotfiles/blob/master/bin/qutebrowser
@@ -147,7 +161,14 @@ runQb() {
     ln -fsT "$XDG_DATA_HOME/qutebrowser/$session" "$basedir/data"
   fi
 
-  $qutebrowser --set window.title_format "{perc}qute [${session}]{title_sep}{current_title}" "$@" &>/dev/null &
+  # Launch qutebrowser with a unique app ID for each profile.
+  # X11 uses the  --qt-arg name to set WM_CLASS
+  # Wayland uses --desktop-file-name to set app_id
+  # Requires Qutebrowser > 1.14.1
+  $qutebrowser --set window.title_format "{perc}qute [${session}]{title_sep}{current_title}" \
+     --desktop-file-name "qutebrowser-$session" \
+     --qt-arg       name "qutebrowser-$session" \
+    "$@" &>/dev/null &
 }
 
 #uid=$(id -u)
@@ -256,11 +277,13 @@ elif [ $choose -eq 1 ]; then
 elif [ -n "$load" ]; then
   [ -n "$new" ] && die "cannot use --load with --new"
   checkProfileExists "$load"
-  
   runQbWithProfile "$load"
 
 elif [ -n "$new" ]; then
   [ -n "$load" ] && die "cannot use --load with --new"
-  
+
+  createDesktopFile "$new"
+  echo "Qutebrowser profile '$new' created."
+
   runQbWithProfile "$new"
 fi


### PR DESCRIPTION
Fixes #7 and #8, depends on #9.

It could be approved by adding a check that the qutebrowser .desktop files exists
before attempting to copy it.

Also, if there's a way to look up the location of Qute's .desktop file path instead of hardcoding one,
that would be better.
