### PR TITLE
Add support for unique WM_CLASS/app_id, generate .desktop files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ To create a new profile, just call the script:
 
 You'll get a rofi/dmenu prompt asking for a profile name. Type one in and hit enter, and qutebrowser will load your profile.
 
-Note that:
+## Features
 
  * qutebrowser's window will have `[my-profile-name]` at the start, so you can easily distinguish different qutebrowsers loaded with different profiles
  * qutebrowser loads configuration from the normal location (and all qutebrowsers share configuration regardless of profile, this includes quickmarks/bookmarks)
+   * If you need some profile-specific configuration like a custom downloads directory, using the `--set` option with `--new` will set these in the generated `.desktop` file.
  * other data, such as session history, cache, cookies, etc, will be unique to that profile
  * A new `.desktop` file will be created for each profile, allowing you to launch each one using a GUI launcher. Name will be "Qute [$profile]"
  * Each profile will be treated as a unique app by the window managers because we set a unique WM\_CLASS for X11 and a unique app\_id for Wayland (requires Qutebrowser > 1.14.1).
@@ -61,6 +62,10 @@ USAGE
   
   --dmenu
     Override location of dmenu. Rofi is autodetected without you needing to set this.
+
+  --set OPTION VALUE
+    When used with --new, adds `qutebrowser --set` options in generated `.desktop` file.
+    May be specified multiple times.
   
   --qutebrowser
     Override location of qutebrowser to call.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # qutebrowser-profile
 
-A simple wrapper script for qutebrowser that allows you to maintain different profiles, each with their own history and session state but sharing the same `config.py`.
+A wrapper script for qutebrowser that allows you to maintain different profiles, each with their own history and session state but sharing the same `config.py`.
 
 ## Why?
 
@@ -21,9 +21,13 @@ To create a new profile, just call the script:
 You'll get a rofi/dmenu prompt asking for a profile name. Type one in and hit enter, and qutebrowser will load your profile.
 
 Note that:
-* qutebrowser's window will have `[my-profile-name]` at the start, so you can easily distinguish different qutebrowsers loaded with different profiles
-* qutebrowser loads configuration from the normal location (and all qutebrowsers share configuration regardless of profile, this includes quickmarks/bookmarks)
-* other data, such as session history, cache, cookies, etc, will be unique to that profile
+
+ * qutebrowser's window will have `[my-profile-name]` at the start, so you can easily distinguish different qutebrowsers loaded with different profiles
+ * qutebrowser loads configuration from the normal location (and all qutebrowsers share configuration regardless of profile, this includes quickmarks/bookmarks)
+ * other data, such as session history, cache, cookies, etc, will be unique to that profile
+ * A new `.desktop` file will be created for each profile, allowing you to launch each one using a GUI launcher. Name will be "Qute [$profile]"
+ * Each profile will be treated as a unique app by the window managers because we set a unique WM\_CLASS for X11 and a unique app\_id for Wayland (requires Qutebrowser > 1.14.1).
+ * The same Qutebrowser icon is used for the new profiles, but you can reference your own by editing `~/.local/share/applications/qutebrowser-$profile.desktop`.
 
 ## Other options
 

--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -107,7 +107,7 @@ createDesktopFile() {
   appId="qutebrowser-$profile"
   newExec="Exec=qutebrowser-profile "
   newExec+="--load '$profile' "
-  newExec+="${setFlags[@]}"
+  newExec+=$setFlags
 
   # Escape for sed
   newExecEscaped=$(sed 's/[&/\]/\\&/g' <<<"$newExec")
@@ -176,11 +176,11 @@ runQb() {
   # Launch qutebrowser with a unique app ID for each profile.
   # X11 uses the  --qt-arg name to set WM_CLASS
   # Wayland uses --desktop-file-name to set app_id
-  # Requires Qutebrowser > 1.14.1
+  # Requires Qutebrowser > 1.14.1 and Bash 4.4
   $qutebrowser --set window.title_format "{perc}qute [${session}]{title_sep}{current_title}" \
      --desktop-file-name "qutebrowser-$session" \
      --qt-arg       name "qutebrowser-$session" \
-     ${setFlags[@]} \
+     $setFlags \
     "$@" &>/dev/null &
 }
 
@@ -195,7 +195,7 @@ load=""
 new=""
 rofi=0
 declare -a qbArgs
-declare -a setFlags
+setFlags=''
 
 if [ $# -eq 0 ]; then
   # if no args specified, assume --choose
@@ -222,11 +222,13 @@ else
         [ $# -ge 2 ] || die "you must specify a profile to create\n\n$usage"
         new="$2";shift; shift
         ;;
-
+     
       # For use with --new, pass --set OPTION VALUE to qutebrowser
       # May be provided multiple times.
       --set)
-        setFlags+=("$1 $2 $3")
+       # TODO: Fix the quoting here
+        #setFlags+=$(printf "%q %q '%q'\n" "$1" "$2" "$3")
+        setFlags+=$(printf '%s %s "%s" ' "$1" "$2" "$3")
         shift; shift; shift;
         ;;
 

--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -129,6 +129,7 @@ runQb() {
   # $XDG_RUNTIME_DIR/qutebrowser/$session/data → $XDG_DATA_HOME/qutebrowser/$session
   # $XDG_RUNTIME_DIR/qutebrowser/$session/data/userscripts → $XDG_DATA_HOME/qutebrowser/userscripts
   # $XDG_RUNTIME_DIR/qutebrowser/$session/data/greasemonkey → $XDG_DATA_HOME/qutebrowser/greasemonkey
+  # $XDG_RUNTIME_DIR/qutebrowser/$session/data/qtwebengine_dictionaries → $XDG_DATA_HOME/qutebrowser/qtwebengine_dictionaries
   # $XDG_RUNTIME_DIR/qutebrowser/$session/config → $XDG_CONFIG_HOME/qutebrowser
   # $XDG_RUNTIME_DIR/qutebrowser/$session/runtime (no symlink, regular directory)
   #
@@ -175,6 +176,7 @@ runQb() {
     ln -fsT "$XDG_DATA_HOME/qutebrowser/$session" "$basedir/data"
     ln -fsT "$XDG_DATA_HOME/qutebrowser/userscripts" "$basedir/data/userscripts"
     ln -fsT "$XDG_DATA_HOME/qutebrowser/greasemonkey" "$basedir/data/greasemonkey"
+    ln -fsT "$XDG_DATA_HOME/qutebrowser/qtwebengine_dictionaries" "$basedir/data/qtwebengine_dictionaries"
   fi
 
   # Launch qutebrowser with a unique app ID for each profile.

--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -127,6 +127,8 @@ runQb() {
   
   # $XDG_RUNTIME_DIR/qutebrowser/$session/cache → $XDG_CACHE_HOME/qutebrowser/$session
   # $XDG_RUNTIME_DIR/qutebrowser/$session/data → $XDG_DATA_HOME/qutebrowser/$session
+  # $XDG_RUNTIME_DIR/qutebrowser/$session/data/userscripts → $XDG_DATA_HOME/qutebrowser/userscripts
+  # $XDG_RUNTIME_DIR/qutebrowser/$session/data/greasemonkey → $XDG_DATA_HOME/qutebrowser/greasemonkey
   # $XDG_RUNTIME_DIR/qutebrowser/$session/config → $XDG_CONFIG_HOME/qutebrowser
   # $XDG_RUNTIME_DIR/qutebrowser/$session/runtime (no symlink, regular directory)
   #
@@ -171,6 +173,8 @@ runQb() {
     ln -fsT "$XDG_CONFIG_HOME/qutebrowser" "$basedir/config"
     ln -fsT "$XDG_CACHE_HOME/qutebrowser/$session" "$basedir/cache"
     ln -fsT "$XDG_DATA_HOME/qutebrowser/$session" "$basedir/data"
+    ln -fsT "$XDG_DATA_HOME/qutebrowser/userscripts" "$basedir/data/userscripts"
+    ln -fsT "$XDG_DATA_HOME/qutebrowser/greasemonkey" "$basedir/data/greasemonkey"
   fi
 
   # Launch qutebrowser with a unique app ID for each profile.

--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -218,7 +218,7 @@ if [ -z "$dmenu" ]; then
   fi
 fi
 
-if [ -z "$new" ] && [ $choose -eq 0 ] && [ $list -eq 0 ]; then
+if [ -z "$new" ] && [ -z "$load" ] && [ $choose -eq 0 ] && [ $list -eq 0 ]; then
   # if user chose neither --choose or --list, assume --choose
   choose=1
 fi

--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -122,6 +122,19 @@ createDesktopFile() {
           s/StartupWMClass=qutebrowser/StartupWMClass=$appIdEscaped/" $desktopFile
 }
 
+# Create a symlink from <srcdir> to <dstdir>. If dstdir exists, remove it if empty.
+# usage: linkDirIntelligently <srcdir> <dstdir>
+linkDirIntelligently() {
+  srcdir="$1"
+  dstdir="$2"
+
+  if [ ! -L "$dstdir" ] && [ -d "$dstdir" ] && [ -n "$(ls -a $dstdir)" ]; then
+    rmdir $dstdir
+  fi
+
+  ln -fsT "$srcdir" "$dstdir"
+}
+
 # usage: runQb <args>
 runQb() {
   # https://github.com/ayekat/dotfiles/blob/master/bin/qutebrowser
@@ -174,19 +187,21 @@ runQb() {
       "$XDG_DATA_HOME/qutebrowser/$session" \
       "$basedir/runtime"
 
-    ln -fsT "$XDG_CONFIG_HOME/qutebrowser" "$basedir/config"
-    ln -fsT "$XDG_CACHE_HOME/qutebrowser/$session" "$basedir/cache"
-    ln -fsT "$XDG_DATA_HOME/qutebrowser/$session" "$basedir/data"
+    linkDirIntelligently "$XDG_CONFIG_HOME/qutebrowser" "$basedir/config"
+    linkDirIntelligently "$XDG_CACHE_HOME/qutebrowser/$session" "$basedir/cache"
+    linkDirIntelligently "$XDG_DATA_HOME/qutebrowser/$session" "$basedir/data"
 
     errorMsg="Profile %s already has its own %s directory. You will need to merge this manually into $HOME/.local/share/qutebrowser/"
 
-    ln -fsT "$XDG_DATA_HOME/qutebrowser/userscripts" "$basedir/data/userscripts" \
+    linkDirIntelligently "$XDG_DATA_HOME/qutebrowser/userscripts" "$basedir/data/userscripts" \
       || warningMessage $(printf "$errorMsg" $session userscripts)
-    ln -fsT "$XDG_DATA_HOME/qutebrowser/greasemonkey" "$basedir/data/greasemonkey" \
+    linkDirIntelligently "$XDG_DATA_HOME/qutebrowser/greasemonkey" "$basedir/data/greasemonkey" \
       || warningMessage $(printf "$errorMsg" $session greasemonkey)
-    ln -fsT "$XDG_DATA_HOME/qutebrowser/qtwebengine_dictionaries" "$basedir/data/qtwebengine_dictionaries" \
+    linkDirIntelligently "$XDG_DATA_HOME/qutebrowser/qtwebengine_dictionaries" "$basedir/data/qtwebengine_dictionaries" \
       || warningMessage $(printf "$errorMsg" $session qtwebengine_dictionaries)
   fi
+
+  echo "using basedir $basedir"
 
   # Launch qutebrowser with a unique app ID for each profile.
   # X11 uses the  --qt-arg name to set WM_CLASS

--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -173,12 +173,19 @@ runQb() {
       "$XDG_CACHE_HOME/qutebrowser/$session" \
       "$XDG_DATA_HOME/qutebrowser/$session" \
       "$basedir/runtime"
+
     ln -fsT "$XDG_CONFIG_HOME/qutebrowser" "$basedir/config"
     ln -fsT "$XDG_CACHE_HOME/qutebrowser/$session" "$basedir/cache"
     ln -fsT "$XDG_DATA_HOME/qutebrowser/$session" "$basedir/data"
-    ln -fsT "$XDG_DATA_HOME/qutebrowser/userscripts" "$basedir/data/userscripts"
-    ln -fsT "$XDG_DATA_HOME/qutebrowser/greasemonkey" "$basedir/data/greasemonkey"
-    ln -fsT "$XDG_DATA_HOME/qutebrowser/qtwebengine_dictionaries" "$basedir/data/qtwebengine_dictionaries"
+
+    errorMsg="Profile %s already has its own %s directory. You will need to merge this manually into $HOME/.local/share/qutebrowser/"
+
+    ln -fsT "$XDG_DATA_HOME/qutebrowser/userscripts" "$basedir/data/userscripts" \
+      || warningMessage $(printf "$errorMsg" $session userscripts)
+    ln -fsT "$XDG_DATA_HOME/qutebrowser/greasemonkey" "$basedir/data/greasemonkey" \
+      || warningMessage $(printf "$errorMsg" $session greasemonkey)
+    ln -fsT "$XDG_DATA_HOME/qutebrowser/qtwebengine_dictionaries" "$basedir/data/qtwebengine_dictionaries" \
+      || warningMessage $(printf "$errorMsg" $session qtwebengine_dictionaries)
   fi
 
   # Launch qutebrowser with a unique app ID for each profile.
@@ -190,6 +197,21 @@ runQb() {
      --qt-arg       name "${QP_NAME}-$session" \
      $setFlags \
     "$@" &>/dev/null &
+}
+
+# show a warning message, without exiting
+warningMessage() {
+  msg="$@"
+  if $(which zenity &>/dev/null); then
+    zenity --warning --title "$QP_NAME" --text "$msg"
+
+  elif $(which notify-send &>/dev/null); then
+    notify-send -a "$QP_NAME" -i dialog-warning "$QP_NAME: error" "$msg"
+
+  fi
+  
+  # always echo to stderr, in case GUI dialogs don't work/aren't noticed
+  echo "$msg" >&2 
 }
 
 #uid=$(id -u)

--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -48,6 +48,10 @@ USAGE
   
   --dmenu
     Override location of dmenu. Rofi is autodetected without you needing to set this.
+
+  --set OPTION VALUE
+    When used with --new, sets profile-specific config options by passing through
+    the --set flags to qutebrowser. May be specified multiple times.
   
   --qutebrowser
     Override location of qutebrowser to call.
@@ -103,9 +107,17 @@ createDesktopFile() {
   appId="qutebrowser-$profile"
   newExec="Exec=qutebrowser-profile "
   newExec+="--load '$profile' "
-  sed -i "s/Exec=qutebrowser/$newExec/g;
-          s/Name=qutebrowser/Name=Qute [$profile]/;
-          s/StartupWMClass=qutebrowser/StartupWMClass=$appId/" $desktopFile
+  newExec+="${setFlags[@]}"
+
+  # Escape for sed
+  newExecEscaped=$(sed 's/[&/\]/\\&/g' <<<"$newExec")
+  profileEscaped=$(sed 's/[&/\]/\\&/g' <<<"$profile")
+    appIdEscaped=$(sed 's/[&/\]/\\&/g' <<<"$appId")
+
+
+  sed -i "s/Exec=qutebrowser/$newExecEscaped/g;
+          s/Name=qutebrowser/Name=Qute [$profileEscaped]/;
+          s/StartupWMClass=qutebrowser/StartupWMClass=$appIdEscaped/" $desktopFile
 }
 
 # usage: runQb <args>
@@ -168,6 +180,7 @@ runQb() {
   $qutebrowser --set window.title_format "{perc}qute [${session}]{title_sep}{current_title}" \
      --desktop-file-name "qutebrowser-$session" \
      --qt-arg       name "qutebrowser-$session" \
+     ${setFlags[@]} \
     "$@" &>/dev/null &
 }
 
@@ -182,6 +195,7 @@ load=""
 new=""
 rofi=0
 declare -a qbArgs
+declare -a setFlags
 
 if [ $# -eq 0 ]; then
   # if no args specified, assume --choose
@@ -207,6 +221,13 @@ else
       --new|-n)
         [ $# -ge 2 ] || die "you must specify a profile to create\n\n$usage"
         new="$2";shift; shift
+        ;;
+
+      # For use with --new, pass --set OPTION VALUE to qutebrowser
+      # May be provided multiple times.
+      --set)
+        setFlags+=("$1 $2 $3")
+        shift; shift; shift;
         ;;
 
       --restore|-r)

--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -94,6 +94,20 @@ runQbWithProfile() {
   runQb ${qbArgs[@]}
 }
 
+# Copy the canonical Qutebrowser .desktop file and customize it.
+createDesktopFile() {
+  profile="$1"
+  desktopFile="$XDG_DATA_HOME/applications/qutebrowser-$profile.desktop"
+  # XXX Check if this file exists and/or support other locations.
+  cp /usr/share/applications/org.qutebrowser.qutebrowser.desktop $desktopFile
+  appId="qutebrowser-$profile"
+  newExec="Exec=qutebrowser-profile "
+  newExec+="--load '$profile' "
+  sed -i "s/Exec=qutebrowser/$newExec/g;
+          s/Name=qutebrowser/Name=Qute [$profile]/;
+          s/StartupWMClass=qutebrowser/StartupWMClass=$appId/" $desktopFile
+}
+
 # usage: runQb <args>
 runQb() {
   # https://github.com/ayekat/dotfiles/blob/master/bin/qutebrowser
@@ -147,7 +161,14 @@ runQb() {
     ln -fsT "$XDG_DATA_HOME/qutebrowser/$session" "$basedir/data"
   fi
 
-  $qutebrowser --set window.title_format "{perc}qute [${session}]{title_sep}{current_title}" "$@" &>/dev/null &
+  # Launch qutebrowser with a unique app ID for each profile.
+  # X11 uses the  --qt-arg name to set WM_CLASS
+  # Wayland uses --desktop-file-name to set app_id
+  # Requires Qutebrowser > 1.14.1
+  $qutebrowser --set window.title_format "{perc}qute [${session}]{title_sep}{current_title}" \
+     --desktop-file-name "qutebrowser-$session" \
+     --qt-arg       name "qutebrowser-$session" \
+    "$@" &>/dev/null &
 }
 
 #uid=$(id -u)
@@ -256,11 +277,13 @@ elif [ $choose -eq 1 ]; then
 elif [ -n "$load" ]; then
   [ -n "$new" ] && die "cannot use --load with --new"
   checkProfileExists "$load"
-  
   runQbWithProfile "$load"
 
 elif [ -n "$new" ]; then
   [ -n "$load" ] && die "cannot use --load with --new"
-  
+
+  createDesktopFile "$new"
+  echo "Qutebrowser profile '$new' created."
+
   runQbWithProfile "$new"
 fi

--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -23,14 +23,17 @@
 # SOFTWARE.
 #
 
+QP_NAME="qutebrowser-profile"
+QP_VERSION="0.0.1"
+
 # Wrapper for qutebrowser that allows the user to maintain different profiles for qutebrowser
 #
-usage="qutebrowser-profile [--list] [--choose [--only-existing] | --load <name> | --new <name>] [qutebrowser args]"
+usage="$QP_NAME [--list] [--choose [--only-existing] | --load <name> | --new <name>] [qutebrowser args]"
 read -r -d '' help <<EOF
-  qutebrowser-profile - use qutebrowser with per-profile cache, session history, etc
+  $QP_NAME - use qutebrowser with per-profile cache, session history, etc
 
 USAGE
-  qutebrowser-profile [--list] [--choose [--only-existing] | --load <name> | --new <name>] [qutebrowser args]
+  $QP_NAME [--list] [--choose [--only-existing] | --load <name> | --new <name>] [qutebrowser args]
 
   --choose, -c
     If specified, the user is asked to select a profile via dmenu. If dmenu returns an empty string or non-zero 
@@ -64,7 +67,6 @@ Released under the MIT Licence. See LICENCE file for full licence terms.
 EOF
 
 set -eu
-QP_VERSION="0.0.1"
 
 # Set default values as defined in XDG base directory spec
 # https://specifications.freedesktop.org/basedir-spec/latest/
@@ -101,22 +103,22 @@ runQbWithProfile() {
 # Copy the canonical Qutebrowser .desktop file and customize it.
 createDesktopFile() {
   profile="$1"
-  desktopFile="$XDG_DATA_HOME/applications/qutebrowser-$profile.desktop"
+  desktopFile="$XDG_DATA_HOME/applications/${QP_NAME}-${profile}.desktop"
   # XXX Check if this file exists and/or support other locations.
   cp /usr/share/applications/org.qutebrowser.qutebrowser.desktop $desktopFile
-  appId="qutebrowser-$profile"
-  newExec="Exec=qutebrowser-profile "
+  appId="${QP_NAME}-${profile}"
+  newExec="Exec=$QP_NAME "
   newExec+="--load '$profile' "
   newExec+=$setFlags
 
   # Escape for sed
   newExecEscaped=$(sed 's/[&/\]/\\&/g' <<<"$newExec")
   profileEscaped=$(sed 's/[&/\]/\\&/g' <<<"$profile")
-    appIdEscaped=$(sed 's/[&/\]/\\&/g' <<<"$appId")
+  appIdEscaped=$(sed 's/[&/\]/\\&/g' <<<"$appId")
 
 
   sed -i "s/Exec=qutebrowser/$newExecEscaped/g;
-          s/Name=qutebrowser/Name=Qute [$profileEscaped]/;
+          s/Name=qutebrowser/Name=$QP_NAME [$profileEscaped]/;
           s/StartupWMClass=qutebrowser/StartupWMClass=$appIdEscaped/" $desktopFile
 }
 
@@ -183,9 +185,9 @@ runQb() {
   # X11 uses the  --qt-arg name to set WM_CLASS
   # Wayland uses --desktop-file-name to set app_id
   # Requires Qutebrowser > 1.14.1 and Bash 4.4
-  $qutebrowser --set window.title_format "{perc}qute [${session}]{title_sep}{current_title}" \
-     --desktop-file-name "qutebrowser-$session" \
-     --qt-arg       name "qutebrowser-$session" \
+  $qutebrowser --set window.title_format "{perc}$QP_NAME [${session}]{title_sep}{current_title}" \
+     --desktop-file-name "${QP_NAME}-$session" \
+     --qt-arg       name "${QP_NAME}-$session" \
      $setFlags \
     "$@" &>/dev/null &
 }
@@ -312,7 +314,7 @@ elif [ -n "$new" ]; then
   [ -n "$load" ] && die "cannot use --load with --new"
 
   createDesktopFile "$new"
-  echo "Qutebrowser profile '$new' created."
+  echo "qutebrowser profile '$new' created."
 
   runQbWithProfile "$new"
 fi


### PR DESCRIPTION
This is based on @markstos code in #10, and adds a few small tweaks:

* centralises references to `qutebrowser-profile` to new `$QP_NAME` variable
* changes references to 'qute' in desktop files and titlebar to `$QP_NAME`