### PR TITLE
quit throwing away STDERR-- it provides valuable debugging information

### DIFF
--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -147,7 +147,7 @@ runQb() {
     ln -fsT "$XDG_DATA_HOME/qutebrowser/$session" "$basedir/data"
   fi
 
-  $qutebrowser --set window.title_format "{perc}qute [${session}]{title_sep}{current_title}" "$@" &>/dev/null &
+  $qutebrowser --set window.title_format "{perc}qute [${session}]{title_sep}{current_title}" "$@" &
 }
 
 #uid=$(id -u)


### PR DESCRIPTION
Tonight I thought `qutebrowser-profile` was failing. Nothing happened when I ran it. 

Then I made this change locally so that STDERR was printed and `qutebrowser` shared a crucial detail: The browser window happened an opened an existing instance (on a desktop that was hidden).

Such diagnostic messages can be a big time saver so let's not throw them away.