### PR TITLE
Allow the use of '--load' without an error

### DIFF
--- a/qutebrowser-profile
+++ b/qutebrowser-profile
@@ -218,7 +218,7 @@ if [ -z "$dmenu" ]; then
   fi
 fi
 
-if [ -z "$new" ] && [ $choose -eq 0 ] && [ $list -eq 0 ]; then
+if [ -z "$load" ] && [ -z "$new" ] && [ $choose -eq 0 ] && [ $list -eq 0 ]; then
   # if user chose neither --choose or --list, assume --choose
   choose=1
 fi


### PR DESCRIPTION
If you used the arguments '--load [name]' it would respond with 'cannot use --choose with --load'. This fixes that.